### PR TITLE
handline the case of emptuy line

### DIFF
--- a/cdliconll2conllu/converter.py
+++ b/cdliconll2conllu/converter.py
@@ -39,6 +39,8 @@ class CdliCoNLLtoCoNLLUConverter:
 
             for line in openedCDLICoNLLFile:
                 line = line.strip()
+                if(len(line)==0):
+                    continue
                 if line[0] != '#':
                     line = line.split()
                     inputLines.append(line)


### PR DESCRIPTION
 by using the continue statement if the line is empty. The issue mentioned [here](https://github.com/cdli-gh/CDLI-CoNLL-to-CoNLLU-Converter/issues/7).