### PR TITLE
splitting on the basis of tabs instead of space

### DIFF
--- a/cdliconll2conllu/converter.py
+++ b/cdliconll2conllu/converter.py
@@ -40,7 +40,7 @@ class CdliCoNLLtoCoNLLUConverter:
             for line in openedCDLICoNLLFile:
                 line = line.strip()
                 if line[0] != '#':
-                    line = line.split()
+                    line = line.split("\t")
                     inputLines.append(line)
                 else:
                     self.headerLines.append(line)


### PR DESCRIPTION
Currently, a line is being split on the bases of spaces, but as per the issue created here by me [here](https://github.com/cdli-gh/CDLI-CoNLL-to-CoNLLU-Converter/issues/6),  in this PR, they would be split using `\t`.